### PR TITLE
`wp-env` の日本語版ドキュメントについて誤字修正等

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -312,7 +312,7 @@ Positionals:
 wp-env start [ref]
 
 WordPress 開発環境をポート 8888 (​http://localhost:8888​) で (ポートは WP_ENV_PORT で指定可)、
-テスト環境を 8889 (​http://localhost:8889​) で (ポートは WP_ENV_TESTS_PORT で指定化) 開始します。
+テスト環境を 8889 (​http://localhost:8889​) で (ポートは WP_ENV_TESTS_PORT で指定可) 開始します。
 コマンドは WordPress インストールディレクトリー、プラグインやテーマのディレクトリー、
 または .wp-env.json ファイルのあるディレクトリーで実行する必要があります。
 
@@ -488,7 +488,7 @@ You can customize the WordPress installation, plugins and themes that the develo
 
 WordPress のインストールや開発環境で使用するプラグインやテーマをカスタマイズできます。`.wp-env.json` ファイルに指定し、同じディレクトリーで `wp-env` を実行してください。
 
-`.wp-env.json` には5つのフィールドがあります。
+`.wp-env.json` には7つのフィールドがあります。
 
 <!-- 
 | Field         | Type           | Default                                    | Description                                                                                                               |
@@ -604,7 +604,7 @@ This is useful for integration testing: that is, testing how old versions of Wor
  -->
 #### 完全なテスト環境
 
-いんてグレショーンテストで便利です。古いバージョンの WordPress と異なるプラグインの組み合わせで互いに与える影響をテストできます。
+インテグレショーンテストで便利です。古いバージョンの WordPress と異なるプラグインの組み合わせで互いに与える影響をテストできます。
 
 ```json
 {


### PR DESCRIPTION
## Description

`wp-env` の日本語版ドキュメントについて以下の誤字修正等を実施しました。

- 指定化→指定可
- フィールドの数をテーブルの項目数と一致
- いんてグレーション→インテグレーション
