### PR TITLE
リンク切れの修正

### DIFF
--- a/docs/reference-guides/slotfills/README.md
+++ b/docs/reference-guides/slotfills/README.md
@@ -148,7 +148,7 @@ The following SlotFills are available in the `edit-post` package. Please refer t
 
 `edit-post` パッケージでは以下の SlotFill が利用可能です。詳細な使用方法と例についてはそれぞれの項目を参照してください。
 
-- [MainDashboardButton](https://developer.wordpress.org/block-editor/developers/slotfills/main-dashboard-button.md)
+- [MainDashboardButton](https://developer.wordpress.org/block-editor/developers/slotfills/main-dashboard-button/)
 - [PluginBlockSettingsMenuItem](https://developer.wordpress.org/block-editor/developers/slotfills/plugin-block-settings-menu-item/)
 - [PluginDocumentSettingPanel](https://developer.wordpress.org/block-editor/developers/slotfills/plugin-document-setting-panel/)
 - [PluginMoreMenuItem](https://developer.wordpress.org/block-editor/developers/slotfills/plugin-more-menu-item/)


### PR DESCRIPTION
WordPressフォーラムにて[リンク切れの報告](https://ja.wordpress.org/support/topic/maindashboardbutton%e3%83%aa%e3%83%b3%e3%82%af%e3%81%aeurl%e9%96%93%e9%81%95%e3%81%84/)がありましたので、修正いたしました。

